### PR TITLE
Streaming example session management fix

### DIFF
--- a/SportingSolutions.Udapi.Sdk.StreamingExample.Console/SportingSolutions.Udapi.Sdk.StreamingExample.Console.csproj
+++ b/SportingSolutions.Udapi.Sdk.StreamingExample.Console/SportingSolutions.Udapi.Sdk.StreamingExample.Console.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StreamListener.cs" />
     <Compile Include="Udapi\BaseSS.cs" />
+    <Compile Include="Udapi\SessionContainer.cs" />
     <Compile Include="Udapi\Udapi.cs" />
     <Compile Include="Udapi\UdapiFeature.cs" />
     <Compile Include="Udapi\UdapiResource.cs" />

--- a/SportingSolutions.Udapi.Sdk.StreamingExample.Console/Udapi/BaseSS.cs
+++ b/SportingSolutions.Udapi.Sdk.StreamingExample.Console/Udapi/BaseSS.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using SportingSolutions.Udapi.Sdk.Interfaces;
 using SportingSolutions.Udapi.Sdk.StreamingExample.Console.Configuration;
 using log4net;
-using ICredentials = SportingSolutions.Udapi.Sdk.Interfaces.ICredentials;
 
 namespace SportingSolutions.Udapi.Sdk.StreamingExample.Console.Udapi
 {
@@ -18,46 +17,23 @@ namespace SportingSolutions.Udapi.Sdk.StreamingExample.Console.Udapi
         protected ReconnectDelegate TheReconnectMethod;
 
         //The underlying Sporting Solutions session
-        private static volatile ISession theSession;
-        private static readonly object syncRoot = new Object();
+        private readonly SessionContainer _sessionContainer;
         
         private readonly ISettings _settings;
 
         protected T _theRealObject;
 
+        internal BaseSS()
+        {
+            _sessionContainer = new SessionContainer(
+                new Credentials { UserName = _settings.User, Password = _settings.Password },
+                new Uri(_settings.Url));
+        }
+
         //Singleton Session, all child classes spawn from the same session
         protected ISession Session
         {
-            get
-            {
-                if (theSession == null)
-                {
-                    lock (syncRoot)
-                    {
-                        if (theSession == null)
-                        {
-                            _logger.Info("Connecting to UDAPI....");
-                            ICredentials credentials = new Credentials { UserName = _settings.User, Password = _settings.Password };
-                            theSession = SessionFactory.CreateSession(new Uri(_settings.Url), credentials);
-                            _logger.Info("Successfully connected to UDAPI.");
-                        }
-                    }
-                }
-                return theSession;
-            }
-            private set
-            {
-                if(theSession != null)
-                {
-                    lock(syncRoot)
-                    {
-                        if(theSession != null)
-                        {
-                            theSession = value;
-                        }
-                    }
-                }
-            }
+            get { return _sessionContainer.Session; }
         }
 
         internal BaseSS(ISettings settings = null)
@@ -144,9 +120,8 @@ namespace SportingSolutions.Udapi.Sdk.StreamingExample.Console.Udapi
                 try
                 {
                     if (connectSession)
-                    {
-                        Session = null;
-                    }
+                        _sessionContainer.ReleaseSession();;
+                    
                     TheReconnectMethod();
                     return;
                 }

--- a/SportingSolutions.Udapi.Sdk.StreamingExample.Console/Udapi/SessionContainer.cs
+++ b/SportingSolutions.Udapi.Sdk.StreamingExample.Console/Udapi/SessionContainer.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using SportingSolutions.Udapi.Sdk.Interfaces;
+using log4net;
+
+namespace SportingSolutions.Udapi.Sdk.StreamingExample.Console.Udapi
+{
+    public class SessionContainer 
+    {
+        private static volatile ISession _theSession;
+        private static readonly object SyncRoot = new Object();
+
+        private readonly ILog _logger = LogManager.GetLogger(typeof(SessionContainer).ToString());
+        private readonly ICredentials _credentials;
+        private readonly Uri _url;
+
+        public SessionContainer(ICredentials credentials, Uri url)
+        {
+            _credentials = credentials;
+            _url = url;
+        }
+
+        public ISession Session
+        {
+            get
+            {
+                if (_theSession == null)
+                {
+                    lock (SyncRoot)
+                    {
+                        if (_theSession == null)
+                        {
+                            _logger.Info("Connecting to UDAPI....");
+                            _theSession = SessionFactory.CreateSession(_url, _credentials);
+                            _logger.Info("Successfully connected to UDAPI.");
+                        }
+                    }
+                }
+
+                return _theSession;
+            }
+        }
+
+        public void ReleaseSession()
+        {
+            lock (SyncRoot)
+            {
+                _theSession = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Static fields in generic base classes are not shared among closed sub
types:
http://confluence.jetbrains.net/display/ReSharper/Static+field+in+generic+type

Demo here:  https://dl.dropbox.com/u/30149716/StaticGenericScratch.zip

This commit implements a SessionContainer reference by the genenric base
classes thus ensuring the session is shared between all closed sub
types.
